### PR TITLE
Update GitHub Actions to Node.js 24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: paolino/dev-assets/setup-nix@v0.0.1
         with:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -15,7 +15,7 @@ jobs:
   docs:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: paolino/dev-assets/setup-nix@v0.0.1
         with:


### PR DESCRIPTION
Bump GitHub Actions to Node.js 24 compatible versions. Node.js 20 is deprecated June 2026.